### PR TITLE
CHANGED: refactor markup mode

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -16,6 +16,7 @@ lib/App/Asciio/Ascii.pm
 lib/App/Asciio/BindingsHelp.pm
 lib/App/Asciio/Boxes.pm
 lib/App/Asciio/Connections.pm
+lib/App/Asciio/Markup.pm
 lib/App/Asciio/Cross.pm
 lib/App/Asciio/Dialogs.pm
 lib/App/Asciio/Elements.pm

--- a/MANIFEST
+++ b/MANIFEST
@@ -35,6 +35,7 @@ lib/App/Asciio/Ascii.pm
 lib/App/Asciio/BindingsHelp.pm
 lib/App/Asciio/Boxes.pm
 lib/App/Asciio/Connections.pm
+lib/App/Asciio/Markup.pm
 lib/App/Asciio/Cross.pm
 lib/App/Asciio/Dialogs.pm
 lib/App/Asciio/Elements.pm

--- a/documentation/mdbook_asciio/src/editing_elements/markup_mode.md
+++ b/documentation/mdbook_asciio/src/editing_elements/markup_mode.md
@@ -4,7 +4,7 @@ We can use color in asciio, But if exported, the color information will be lost.
 The markup mode adds marks in the chart, and these marks can be retained when 
 exporting, so that special effects can be displayed in some specific software.
 
-## Use markup mode
+## 1 Use markup mode
 
 To use marks in the chart, turn on this option in the configuration.The markup 
 enable variable is the basic attribute of the chart and cannot be changed at 
@@ -12,12 +12,21 @@ runtime.
 
 
 ```perl
-USE_MARKUP_MODE => 1,
+USE_MARKUP_MODE => 'zimwiki',
 ```
 
-## Edit marks
+If you do not need to use any markup mode, please keep this variable empty.
 
-markup mode currently supports text editing of box type elements.Just place the text 
+```perl
+USE_MARKUP_MODE => '',
+```
+>Currently, only zimwiki format markup is supported, then markdown format or pure
+html format may be supported in the future.
+
+## 2 zimwiki format description
+### 2.1 Edit marks
+
+zimwiki markup mode currently supports text editing of box type elements.Just place the text 
 in the middle of the marks.
 
 Currently supports 5 types of markers: 
@@ -51,7 +60,7 @@ Marks can only be valid for a single line, not multi lines.
 and it does not make much sense
 
 
-## Export
+### 2.2 Export
 
 Normally, when exporting to ascii, you will get the following text
 

--- a/lib/App/Asciio.pm
+++ b/lib/App/Asciio.pm
@@ -12,7 +12,6 @@ use List::Util qw(min max first) ;
 use List::MoreUtils qw(any minmax first_value) ;
 
 use App::Asciio::Actions ;
-use App::Asciio::Actions ;
 use App::Asciio::Ascii ;
 use App::Asciio::Dialogs ;
 use App::Asciio::Elements ;
@@ -21,6 +20,7 @@ use App::Asciio::Menues ;
 use App::Asciio::Options ;
 use App::Asciio::Setup ;
 use App::Asciio::String ;
+use App::Asciio::Markup ;
 use App::Asciio::Undo ;
 
 #-----------------------------------------------------------------------------
@@ -663,6 +663,8 @@ $self->{CURRENT_ACTIONS} = $self->{ACTIONS} ;
 $self->set_font($self->{FONT_FAMILY}, $self->{FONT_SIZE}) ;
 
 $self->{TAB_AS_SPACES} = '   ' unless defined $self->{TAB_AS_SPACES} ;
+
+App::Asciio::Markup::use_markup($self->{USE_MARKUP_MODE}) ;
 }
 
 #-----------------------------------------------------------------------------

--- a/lib/App/Asciio/Actions/Clipboard.pm
+++ b/lib/App/Asciio/Actions/Clipboard.pm
@@ -109,7 +109,7 @@ close CLIPBOARD ;
 
 #----------------------------------------------------------------------------------------------
 
-sub export_to_clipboard_as_wiki
+sub export_to_clipboard_as_markup
 {
 my ($self) = @_ ;
 
@@ -117,7 +117,7 @@ use open qw( :std :encoding(UTF-8) ) ;
 open CLIPBOARD, "| xsel -i -b -p"  or die "can't copy to clipboard: $!" ;
 local $SIG{PIPE} = sub { die "xsel pipe broke" } ;
 
-print CLIPBOARD $self->transform_elements_to_wiki_buffer($self->get_selected_elements(1)) ;
+print CLIPBOARD $self->transform_elements_to_zim_wiki_buffer($self->get_selected_elements(1)) ;
 close CLIPBOARD ;
 }
 

--- a/lib/App/Asciio/Cross.pm
+++ b/lib/App/Asciio/Cross.pm
@@ -11,7 +11,10 @@ use Clone;
 
 use List::Util qw(first) ;
 use List::MoreUtils qw(any) ;
+
 use App::Asciio::String ;
+use App::Asciio::Markup ;
+
 
 sub get_ascii_array_and_crossings
 {
@@ -33,13 +36,9 @@ for my $element (@{$asciio->{ELEMENTS}})
 			
 			my $y = $element->{Y} + $strip->{Y_OFFSET} + $line_index ;
 			
-			next if defined $start_y && ($y < $start_y || $y >= $end_y) ; 
-			
-			if($asciio->{USE_MARKUP_MODE})
-				{
-				$sub_strip =~ s/(<[bius]>)+([^<]+)(<\/[bius]>)+/$2/g ;
-				$sub_strip =~ s/<span link="[^<]+">([^<]+)<\/span>/$1/g ;
-				}
+			next if defined $start_y && ($y < $start_y || $y >= $end_y) ;
+
+			$sub_strip = $USE_MARKUP_CLASS->delete_markup_characters($sub_strip) ;
 			
 			my $character_index = 0 ;
 			

--- a/lib/App/Asciio/GTK/Asciio.pm
+++ b/lib/App/Asciio/GTK/Asciio.pm
@@ -29,6 +29,7 @@ use App::Asciio::GTK::Asciio::Menues ;
 
 use App::Asciio::Cross ;
 use App::Asciio::String ;
+use App::Asciio::Markup ;
 
 sub hide_pointer
 {
@@ -689,18 +690,9 @@ unless (defined $renderings)
 					my $layout = Pango::Cairo::create_layout($gc) ;
 					
 					$layout->set_font_description($font_description) ;
-					if($self->{USE_MARKUP_MODE} && ($line =~ /<\/?[bius]>/ || $line =~ /<span link="[^<]+">([^<]+)<\/span>/))
-						{
-						#~ link fomart: <span link="">something</span>
-						#~ convert to:  <span underline="double">something</span>
-						$line =~ s/<span link="[^<]+">([^<]+)<\/span>/<span underline="double">$1<\/span>/g;
-						$layout->set_markup($line) ;
-						}
-					else
-						{
-						$layout->set_text($line) ;
-						}
-					
+
+					$USE_MARKUP_CLASS->ui_show_markup_characters($layout, $line) ;
+
 					Pango::Cairo::show_layout($gc, $layout);
 					}
 				

--- a/lib/App/Asciio/GTK/Asciio/Dialogs.pm
+++ b/lib/App/Asciio/GTK/Asciio/Dialogs.pm
@@ -282,7 +282,7 @@ else
 	@text_lines = ('') ;
 	}
 
-my $text_width = max(map {$self->get_unicode_length($_)} @text_lines);
+my $text_width = max(map {unicode_length($_)} @text_lines);
 my $text_heigh = @text_lines;
 $text_width = max($text_width, 3) ;
 $text_heigh =max($text_heigh, 3) ;

--- a/lib/App/Asciio/Markup.pm
+++ b/lib/App/Asciio/Markup.pm
@@ -1,0 +1,218 @@
+
+package App::Asciio::Markup ;
+
+require Exporter ;
+@ISA = qw(Exporter) ;
+@EXPORT = qw(
+	$USE_MARKUP_CLASS
+	) ;
+
+$|++ ;
+
+use strict;
+use warnings;
+use utf8;
+
+use App::Asciio::String ;
+
+
+our ($USE_MARKUP_CLASS) ;
+$USE_MARKUP_CLASS = App::Asciio::Markup->new() ;
+
+#-----------------------------------------------------------------------------
+
+sub new {
+	my $class = shift ;
+	my $self = {} ;
+	bless $self, $class ;
+	return $self ;
+}
+
+#-----------------------------------------------------------------------------
+
+sub use_markup
+{
+my ($use_it) = @_ ;
+
+if($use_it eq 'zimwiki')
+	{
+	$USE_MARKUP_CLASS = App::Asciio::Zimwiki->new() ;
+	}
+else
+	{
+	$USE_MARKUP_CLASS = App::Asciio::Markup->new() ;
+	}
+}
+
+#-----------------------------------------------------------------------------
+
+sub delete_markup_characters { my ($self, $string) = @_ ; return $string ; }
+
+#-----------------------------------------------------------------------------
+
+sub get_markup_coordinates { ; }
+
+#-----------------------------------------------------------------------------
+
+sub get_markup_characters_array
+{
+my ($self, $markup_coordinate, @lines) = @_ ;
+
+return (@lines) ;
+}
+
+#-----------------------------------------------------------------------------
+
+sub ui_show_markup_characters
+{
+my ($self, $layout, $line) = @_ ;
+
+$layout->set_text($line) ;
+}
+
+#-----------------------------------------------------------------------------
+#-----------------------------------------------------------------------------
+
+package App::Asciio::Zimwiki ;
+use base qw/App::Asciio::Markup/ ;
+
+use Memoize ;
+memoize('convert_markup_string') ;
+memoize('del_markup_characters') ;
+
+#-----------------------------------------------------------------------------
+
+sub is_markup_string
+{
+my ($string) = @_;
+
+return (   $string =~ /(<[bius]>)+([^<]+)(<\/[bius]>)+/ 
+		|| $string =~ /<span link="[^<]+">([^<]+)<\/span>/) ;
+}
+
+#-----------------------------------------------------------------------------
+
+sub del_markup_characters
+{
+my ($string) = @_;
+
+$string =~ s/<span link="[^<]+">|<\/span>|<\/?[bius]>//g ;
+
+return $string;
+}
+
+#-----------------------------------------------------------------------------
+
+sub delete_markup_characters
+{
+my ($self, $string) = @_;
+
+return del_markup_characters($string);
+}
+
+#-----------------------------------------------------------------------------
+sub get_markup_coordinates
+{
+my ($self, $element_x, $strip_line, $strip_x, $y) = @_ ;
+
+my %markup_coordinate ;
+
+if(is_markup_string($strip_line))
+	{
+	my $ori_x = 0;
+	while($strip_line =~ /(<\/?[bius]>)+|<\/span>|<span link="[^<]+">/g)
+		{
+		my $sub_str = substr($strip_line, 0, pos($strip_line));
+		$ori_x = $element_x + $strip_x + App::Asciio::String::unicode_length($sub_str) ;
+		my $fit_str = $&;
+		$fit_str =~ s/<\/?b>/\*\*/g;
+		$fit_str =~ s/<\/?u>/__/g;
+		$fit_str =~ s/<\/?i>/\/\//g;
+		$fit_str =~ s/<\/?s>/~~/g;
+		# link [[link|link description]]
+		if($fit_str =~ /<span link="[^<]+">/)
+			{
+			$fit_str =~ s/<span link="([^<]+)">/$1/g;
+			$fit_str = '[[' . $fit_str . '|';
+			}
+		if($fit_str =~ /<\/span>/)
+			{
+			$fit_str = ']]';
+			}
+		$markup_coordinate{$y . '-' . $ori_x} = $fit_str if($ori_x >= 0 && $y >=0);
+		}
+	}
+
+return %markup_coordinate ;
+
+}
+
+#-----------------------------------------------------------------------------
+sub get_markup_characters_array
+{
+my ($self, $markup_coordinate, @lines) = @_ ;
+my (@new_lines, $new_col) ;
+
+for my $row (0 .. $#lines)
+	{
+	$new_col = 0;
+	for my $col (0 .. ($#{$lines[$row]} + 2))
+		{
+		if(exists($markup_coordinate->{$row . '-' . $col}))
+			{
+			for my $single_char (split '', $markup_coordinate->{$row . '-' . $col})
+				{
+				$new_lines[$row][$new_col] = [$single_char];
+				# single char
+				$new_col += App::Asciio::String::unicode_length($single_char);
+				}
+			}
+		$new_lines[$row][$new_col] = $lines[$row][$col] if(defined($lines[$row][$col]));
+		$new_col += 1;
+		}
+	}
+return(@new_lines);
+}
+
+#-----------------------------------------------------------------------------
+#~ link fomart: <span link="">something</span>
+#~ convert to:  <span underline="double">something</span>
+sub convert_markup_string
+{
+my ($string) = @_ ;
+
+my $use_markup_formart = 0 ;
+
+if(is_markup_string($string))
+	{
+	$use_markup_formart = 1 ;
+	# just for display,not really change
+	$string =~ s/<span link="[^<]+">([^<]+)<\/span>/<span underline="double">$1<\/span>/g;
+	}
+
+return ($use_markup_formart, $string) ;
+}
+
+#-----------------------------------------------------------------------------
+
+sub ui_show_markup_characters
+{
+my ($self, $layout, $line) = @_ ;
+
+my ($use_mark_up, $markup_line) = convert_markup_string($line) ;
+
+if($use_mark_up)
+	{
+	$layout->set_markup($markup_line) ;
+	}
+else
+	{
+	$layout->set_text($line) ;
+	}
+}
+
+
+#-----------------------------------------------------------------------------
+
+1 ;
+

--- a/lib/App/Asciio/String.pm
+++ b/lib/App/Asciio/String.pm
@@ -4,7 +4,6 @@ package App::Asciio::String ;
 require Exporter ;
 @ISA = qw(Exporter) ;
 @EXPORT = qw(
-	use_markup
 	unicode_length
 	make_vertical_text
 	) ;
@@ -14,6 +13,8 @@ require Exporter ;
 use strict ; use warnings ;
 use utf8 ;
 
+use App::Asciio::Markup ;
+
 #-----------------------------------------------------------------------------
 
 use Memoize ;
@@ -22,6 +23,8 @@ memoize('unicode_length') ;
 sub unicode_length
 {
 my ($string) = @_ ;
+
+$string = $USE_MARKUP_CLASS->delete_markup_characters($string) ;
 
 my $east_asian_double_width_chars_cnt = grep {$_ =~ /\p{EA=W}|\p{EA=F}/} split('', $string) ;
 my $nonspacing_chars_cnt = grep {$_ =~ /\p{gc:Mn}/} split('', $string) ;
@@ -65,20 +68,6 @@ while($found_character)
 	}
 
 return $vertical ;
-}
-
-#-----------------------------------------------------------------------------
- 
-package App::Asciio ;
-
-sub get_unicode_length
-{
-my ($self, $string) = @_ ;
-
-# Markup is not part of Unicode, handle it in Asciio
-$string =~ s/<span link="[^<]+">|<\/span>|<\/?[bius]>//g if $self->{USE_MARKUP_MODE} ;
-
-return App::Asciio::String::unicode_length($string) ;
 }
 
 #-----------------------------------------------------------------------------

--- a/lib/App/Asciio/Text/Asciio.pm
+++ b/lib/App/Asciio/Text/Asciio.pm
@@ -213,7 +213,7 @@ for my $element (@{$self->{ELEMENTS}})
 			my $strip_color  = color($foreground_color) . color($background_color) ;
 			   $strip_color .= color($self->get_color('selected_element_background')) if $is_selected ;
 			
-			my $line_length = $self->get_unicode_length $line ;
+			my $line_length = unicode_length $line ;
 			$line = sprintf "%0${line_length}d", $element_index if $self->{NUMBERED_OBJECTS} ;
 			
 			my $character_index = 0 ;
@@ -390,7 +390,7 @@ if(defined $self->{SELECTION_RECTANGLE}{END_X})
 		if($start_y > 0 && $start_y <= $ROWS)
 			{
 			my $character_index = 0 ;
-			for (1 .. $self->get_unicode_length($top_bottom))
+			for (1 .. unicode_length($top_bottom))
 				{
 				$text_array->[$start_y][$start_x + $character_index] = ['-', $color] ;
 				$character_index++ ;
@@ -401,7 +401,7 @@ if(defined $self->{SELECTION_RECTANGLE}{END_X})
 			{
 			my $character_index = 0 ;
 			
-			for (1 .. $self->get_unicode_length($top_bottom))
+			for (1 .. unicode_length($top_bottom))
 				{
 				$text_array->[$end_y][$start_x + $character_index] = ['-', $color] ;
 				$character_index++ ;

--- a/lib/App/Asciio/stripes/stripes.pm
+++ b/lib/App/Asciio/stripes/stripes.pm
@@ -5,6 +5,7 @@ use strict;
 use warnings;
 
 use List::Util qw(max) ;
+use App::Asciio::String ;
 
 #---------------------------------------------------------------------------
 

--- a/setup/actions/default_bindings.pl
+++ b/setup/actions/default_bindings.pl
@@ -32,7 +32,7 @@ register_action_handlers
 'Copy to clipboard'                      => [['C00-c', 'C00-Insert', 'y'],             \&App::Asciio::Actions::Clipboard::copy_to_clipboard                                ],
 'Insert from clipboard'                  => [['C00-v', '00S-Insert', 'p'],             \&App::Asciio::Actions::Clipboard::insert_from_clipboard                            ],
 'Export to clipboard & primary as ascii' => [['C00-e', '00S-Y', 'Y'],                  \&App::Asciio::Actions::Clipboard::export_to_clipboard_as_ascii                     ],
-'Export to clipboard & primary as wiki'  => ['C0S-E',                                  \&App::Asciio::Actions::Clipboard::export_to_clipboard_as_wiki                      ],
+'Export to clipboard & primary as markup'=> ['C0S-E',                                  \&App::Asciio::Actions::Clipboard::export_to_clipboard_as_markup                    ],
 'Import from primary to box'             => [['C0S-V', '00S-P', 'P'],                  \&App::Asciio::Actions::Clipboard::import_from_primary_to_box                       ],
 'Import from primary to text'            => [['0A0-p','A-P'],                          \&App::Asciio::Actions::Clipboard::import_from_primary_to_text                      ],
 'Import from clipboard to box'           => [ '0AS-E' ,                                \&App::Asciio::Actions::Clipboard::import_from_clipboard_to_box                     ],

--- a/setup/asciio_object/basic.pl
+++ b/setup/asciio_object/basic.pl
@@ -8,7 +8,7 @@ ZOOM_STEP => 3,
 CANVAS_WIDTH => 200,
 CANVAS_HEIGHT => 150,
 
-USE_MARKUP_MODE => 0,
+USE_MARKUP_MODE => '',
 
 EDIT_TEXT_INLINE => 0,
 GIT_MODE_CONNECTOR_CHAR_LIST => ['*', 'o', '+', 'x', 'X', '┼', '╋', '╬'],

--- a/setup/import_export/perl.pl
+++ b/setup/import_export/perl.pl
@@ -142,7 +142,7 @@ my ($base_name, $path, $extension) = File::Basename::fileparse($file, ('\..*')) 
 my $file_name = $base_name . $extension ;
 
 my @ascii_representation = $self->transform_elements_to_ascii_array() ;
-my $longest_line =  max( map{$self->get_unicode_length($_)} @ascii_representation) ;
+my $longest_line =  max( map{unicode_length($_)} @ascii_representation) ;
 
 my $compressed_self = compress($self->serialize_self() .  '$VAR1 ;') ;
 
@@ -162,7 +162,7 @@ print POD "=for asciio $longest_line $base_name\n\n" ;
 
 for my $diagram_line (@ascii_representation)
 	{
-	my $padding = ' ' x ($longest_line - $self->get_unicode_length($diagram_line)) ;
+	my $padding = ' ' x ($longest_line - unicode_length($diagram_line)) ;
 	my $base64_chunk = substr($base64, 0, $base64_chunk_size, '') || '' ;
 	
 	print POD ' ' ,  $diagram_line, $padding, $BASE64_HEADER, $base64_chunk, "\n"


### PR DESCRIPTION
some optimizations of markup mode

distinguish between functions in normal mode
 and markup mode

The zimwiki module is independent as a subclass

now USE_MARKUP_MODE only in one place